### PR TITLE
Update the protocol to allow multiple outputs for a card transfer transaction

### DIFF
--- a/0001-peerassets-transaction-specification.proto
+++ b/0001-peerassets-transaction-specification.proto
@@ -36,7 +36,7 @@ message CardTransfer {
   uint32 version = 1;
 
   // Amount to transfer
-  uint64 amount = 2;
+  repeated uint64 amounts = 2;
 
   // Number of decimals
   // Should be equal to the number specified in the deck spawn transaction.


### PR DESCRIPTION
Multiple outputs allow:
* lower transaction fees when sending in bulk
* smaller blockchain footprint when sending in bulk
* issue `ONCE` decks can get issued to multiple parties in one transaction